### PR TITLE
add polars-query-dev-complexity tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ You can also try to [Polars plugins Cookiecutter](https://github.com/MarcoGorell
 - [polars-mas](https://github.com/idinsmore1/polars-mas) - A CLI tool and Python library meant to perform large scale multiple association tests, primarily seen in academic research by [@idinsmore1](https://github.com/idinsmore1).
 - [octopolars](https://github.com/lmmx/octopolars) - Pull, filter, and walk a GitHub user's repositories with Polars by [@lmmx](https://github.com/lmmx).
 - [table-diff](https://gitlab.com/parker-research/table-diff) - A tool to generate HTML/Markdown reports highlighting the differences between similar tables by [@parker-research](https://github.com/parker-research).
+- [polars-query-dev-complexity](https://github.com/fran6w/polars-query-dev-complexity) - A lightweight tool for measuring the authoring complexity of Polars LazyFrame queries by [@fran6w](https://github.com/fran6w).
 
 ## Resources
 


### PR DESCRIPTION
Adds polars-query-dev-complexity to “Tools Built with Polars”.

Tool analyzes authoring complexity of Polars LazyFrame queries using the unoptimised explain plan.

No changes to existing entries.