### PR TITLE
Add polars-backtest to finance plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ You can also try to [Polars plugins Cookiecutter](https://github.com/MarcoGorell
 - [polars-fin](https://github.com/LVG77/polars-fin) - Polars plugin to calculate financial metrics by [@LVG77](https://github.com/LVG77).  
 - [polars-bloomberg](https://github.com/MarekOzana/polars-bloomberg) - Polars plugin that extracts Bloomberg’s financial data directly into polars.DataFrame by [@MarekOzana](https://github.com/MarekOzana).
 - [jquantstats](https://github.com/tschm/jquantstats) - Polars/Narwhals-centric tool for the analysis of financial time series data by [@tschm](https://github.com/tschm).
+- [polars-backtest](https://github.com/Yvictor/polars_backtest_extension) - Polars extension for high-performance portfolio backtesting with Rust, Arrow, T+1 execution, and trade reports by [@Yvictor](https://github.com/Yvictor).
 
   
 #### Networking


### PR DESCRIPTION
## What does this PR do?

Adds [polars-backtest](https://github.com/Yvictor/polars_backtest_extension) to the Finance section under Polars plugins. It is a Rust/Arrow-backed Polars extension for portfolio backtesting with T+1 execution and trade reports.

## Requirements for your Awesome item list

- [x] Only has awesome items. Awesome lists are curations of the best, not everything.
- [x] Does not contain items that are unmaintained, has archived repo, deprecated, or missing docs.
- [x] Entries have a description, unless the title is descriptive enough by itself.
- [x] Has consistent formatting and proper spelling/grammar.
- [x] Doesn't use hard-wrapping.
- [x] Your item(s) fit into an existing sections.
- [x] Add your new item to the bottom of the list in a section.
- [x] If a duplicate item exists, discuss why the new item should replace it.
- [x] Check your spelling & grammar.
- [x] The item must follow the required format.
- [x] Be sure to have read the contributing guidelines.