### PR TITLE
Fix Link Check: bot-gated Codeberg, pola.rs canonical URLs, accept 202

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -26,6 +26,10 @@ jobs:
             --no-progress
             --accept 200,206,403,429
             --insecure
-            --exclude "(itnext\.io|gitconnected\.com|pythonspeed\.com|medium\.com)"
+            --max-concurrency 16
+            --max-retries 5
+            --retry-wait-time 5
+            --user-agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            --exclude "(itnext\.io|gitconnected\.com|pythonspeed\.com|medium\.com|codeberg\.org)"
             README.md
           fail: true

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           args: >-
             --no-progress
-            --accept 200,206,403,429
+            --accept 200,202,206,403,429
             --insecure
             --max-concurrency 16
             --max-retries 5

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -27,6 +27,7 @@ jobs:
             --accept 200,202,206,403,429
             --insecure
             --max-concurrency 16
+            --timeout 45
             --max-retries 5
             --retry-wait-time 5
             --user-agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ![Last commit date](https://img.shields.io/github/last-commit/ddotta/awesome-polars?style=flat&label=last%20commit) [![Check Links](https://github.com/ddotta/awesome-polars/actions/workflows/link-check.yml/badge.svg)](https://github.com/ddotta/awesome-polars/actions/workflows/link-check.yml) [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![Track Awesome List](https://www.trackawesomelist.com/badge.svg)](https://www.trackawesomelist.com/ddotta/awesome-polars/)
 
-*A curated list of [Polars](https://www.pola.rs/) docs, talks, tools, examples & articles the internet has to offer.*
+*A curated list of [Polars](https://pola.rs/) docs, talks, tools, examples & articles the internet has to offer.*
 
-[Polars](https://www.pola.rs/) is a lightning-fast DataFrame library for Rust, Python, Node.js and R.
+[Polars](https://pola.rs/) is a lightning-fast DataFrame library for Rust, Python, Node.js and R.
 Implemented in Rust, Polars uses [Apache Arrow Columnar Format](https://arrow.apache.org/docs/format/Columnar.html) as the memory model.
 
-<a href="https://www.pola.rs/" target="_blank" rel="noopener noreferrer">
+<a href="https://pola.rs/" target="_blank" rel="noopener noreferrer">
   <img src="media/logo_awesome_polars.png" alt-text="Polars's logo."/>
 </a>
 
@@ -71,7 +71,7 @@ To see the latest entries in the list, <a href="https://www.trackawesomelist.com
 
 - **September 2025** : [Polars raises €18M Series A](https://pola.rs/posts/series_a/) to build fast, ergonomic data processing at any scale.
 - **September 2025** : Polars launches [Polars Cloud and a Distributed Engine in Open Beta](https://pola.rs/posts/polars-cloud-launch/).
-- **August 2023** : Polars announces that it [has raised a a $4M seed round](https://www.pola.rs/posts/company-announcement/)!
+- **August 2023** : Polars announces that it [has raised a a $4M seed round](https://pola.rs/posts/company-announcement/)!
 - **July 2024** : Python Polars 1.0 release ! See this [blog post special announcement](https://pola.rs/posts/announcing-polars-1/).
 - **September 2024** : Polars has a [new lightweight plotting backend](https://pola.rs/posts/lightweight_plotting/).
 - **September 2024** : [GPU acceleration with Polars and NVIDIA RAPIDS](https://pola.rs/posts/gpu-engine-release/).
@@ -86,7 +86,7 @@ To see the latest entries in the list, <a href="https://www.trackawesomelist.com
 - [Shared library plugins for Polars](https://github.com/pola-rs/pyo3-polars).
 - [Documentation for R API](https://pola-rs.github.io/r-polars/) - Official API Reference for R.
 - [Github: Polars Github Organization](https://github.com/pola-rs) - Official Polars Github repository.
-- [Blog posts from Polars](https://www.pola.rs/posts/) - Official blogs posts from Polars.
+- [Blog posts from Polars](https://pola.rs/posts/) - Official blogs posts from Polars.
 - [Keynote on Polars at EuroSciPy 2023](https://www.youtube.com/watch?v=GTVm3QyJ-3I&t=43s) &#9203; `57 min` - Talk by [\@ritchie46](https://github.com/ritchie46) that dives into Polars and sees what makes it so efficient.  It will touch on technologies like Arrow, Rust, parallelism, data structures, query optimization and more.
 - [Talk about Polars at EuroPython Conference 2023](https://www.youtube.com/watch?v=UwRlFtSd_-8) &#9203; `28 min` - Talk by [\@ritchie46](https://github.com/ritchie46) that introduces Polars and some of its design decisions.
 


### PR DESCRIPTION
The Link Check workflow currently fails, but none of the reported URLs are actually broken — each one is a bot gate that returns a non-2xx status to automated clients while serving the page fine in a browser.

| URL | Cause | Fix |
|---|---|---|
| `codeberg.org/concur1` + `/pl-compare` | Codeberg now sits behind an Anubis anti-bot challenge: **503** for non-browser clients, **403** even with a browser user agent. The repo is alive, but no link checker can verify it. | Added `codeberg\.org` to the exclude regex |
| `www.pola.rs` | Connection reset by peer from the runner. It also 301-redirects to the canonical `pola.rs`. | Rewrote all 5 occurrences in `README.md` to `https://pola.rs/` |
| `statology.org/pandas-vs-polars-...` | SiteGround's `sgcaptcha` gate answers **202** with a `meta refresh` to the challenge page. Whether a request gets challenged depends on the client IP, so this URL returned 200 on one run and 202 on the next. | Added `202` to `--accept` |

Accepting 202 does not weaken the check: a genuinely missing page still returns 404.

Also hardened the checker against the transient failures that caused this in the first place:

- `--max-retries 5 --retry-wait-time 5`
- `--max-concurrency 16` — lychee's default of 128 provokes rate-limit resets and 503s from smaller hosts
- a browser `--user-agent`

## Verification

Link Check passes green on this branch: https://github.com/tschm/awesome-polars/actions/runs/30654553303

I also ran lychee `v0.24.2` (the version the action resolves) locally with the exact new arguments over the full README, and verified each of the three URLs by hand — including reading the raw `sgcaptcha` response body to confirm the 202 is a bot challenge rather than a broken page. The 202 reproduces with lychee's default user agent too, so it is not caused by the user agent added here.

One trade-off worth flagging: the run now takes ~4m30s instead of ~50s, from the lower concurrency and patient retries. That seemed a fair price for a weekly cron over 600+ links, but raising `--max-concurrency` to 32 would roughly halve it if you would rather have the speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)