### PR TITLE
Add quantwave — Polars-native TA and backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ You can also try to [Polars plugins Cookiecutter](https://github.com/MarcoGorell
 - [polars-bloomberg](https://github.com/MarekOzana/polars-bloomberg) - Polars plugin that extracts Bloomberg’s financial data directly into polars.DataFrame by [@MarekOzana](https://github.com/MarekOzana).
 - [jquantstats](https://github.com/tschm/jquantstats) - Polars/Narwhals-centric tool for the analysis of financial time series data by [@tschm](https://github.com/tschm).
 - [polars-backtest](https://github.com/Yvictor/polars_backtest_extension) - Polars extension for high-performance portfolio backtesting with Rust, Arrow, T+1 execution, and trade reports by [@Yvictor](https://github.com/Yvictor).
+- [quantwave](https://github.com/lavs9/quantwave) - Polars-native technical analysis (221 indicators), execution-aware backtesting, and batch/streaming parity with a Rust core and agent skill by [@lavs9](https://github.com/lavs9).
 
 
 #### Networking


### PR DESCRIPTION
## What

Add [QuantWave](https://github.com/lavs9/quantwave) to this list.

## Why it belongs

- Open source (MIT), actively maintained, documented
- Polars-native technical analysis + execution-aware backtester (Rust core)
- Bit-identical batch (Polars) and streaming paths (property-tested)
- Ships an agent skill for silent TA/backtest footguns (AI-assisted quant workflows)

## Links

- Repo: https://github.com/lavs9/quantwave
- Docs: https://lavs9.github.io/quantwave/
- Agent skill: https://lavs9.github.io/quantwave/guides/agent-skill/
- PyPI: https://pypi.org/project/quantwave/

Happy to adjust section placement or wording.

**Section:** Finance (under Polars plugins)