### PR TITLE
Add flexviz — Polars-native interactive visualization at scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ You can also try to [Polars plugins Cookiecutter](https://github.com/MarcoGorell
 - [seaborn_polars](https://github.com/pavelcherepan/seaborn_polars) - Python package to plot Polars DataFrames and LazyFrames with [seaborn](https://seaborn.pydata.org/) by [@pavelcherepan](https://github.com/pavelcherepan).
 - [QuickEcharts](https://github.com/AdrianAntico/QuickEcharts) - Python package for fast and easy echarts with Polars backend by [@AdrianAntico](https://github.com/AdrianAntico).
 - [flowview](https://github.com/guillermodotn/flowview) - A visual debugger that shows what happens at each step of your Polars DataFrame transformations in the terminal. By [@guillermodotn](https://github.com/guillermodotn).
+- [flexviz](https://github.com/flex-analytics/flexviz) - Python library for interactive, cross-filterable charts on 100M+ rows, powered by lazy Polars aggregations and Rust kernels by [@jvdd](https://github.com/jvdd).
 
 #### Miscellaneous
 - [polars-finance](https://github.com/ngriffiths13/polars-finance) - A collection of Python Polars plugins and functions for market data processing by [@ngriffiths13](https://github.com/ngriffiths13).


### PR DESCRIPTION
## What

Add [FlexViz](https://github.com/flex-analytics/flexviz) to this list.

## Why it belongs

- Open source (Apache-2.0), actively maintained, documented
- Polars-native: every zoom, pan and cross-filter is answered by a lazy Polars aggregation, so raw data never reaches the browser
- Ships a Polars expression plugin (`flexviz-polars`, Rust) for the downsampling and binning kernels: `every_nth`, `arg_min_max`, `fixed_hist`, `fixed_hist2d`
- Stays interactive at 100M+ rows (even beyond billion rows).

## Links

- Repo: https://github.com/flex-analytics/flexviz
- Docs: https://docs.flexviz.tech
- Live demo (2 x 100M rows): https://flexviz.tech/demo.html
- Benchmarks: https://flexviz.tech/benchmarks.html
- PyPI: https://pypi.org/project/flexviz/

Happy to adjust section placement or wording.

**Section:** Visualization (under Polars plugins)